### PR TITLE
fix case-sensitive folder name "DataBase" in project file

### DIFF
--- a/SpellWork/SpellWork.csproj
+++ b/SpellWork/SpellWork.csproj
@@ -106,7 +106,7 @@
     </Compile>
     <Compile Include="Extensions\RichTextBoxExtensions.cs" />
     <Compile Include="Extensions\Extensions.cs" />
-    <Compile Include="Database\MySQLConnect.cs" />
+    <Compile Include="DataBase\MySQLConnect.cs" />
     <Compile Include="Forms\FormSettings.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
I have been compiling this program using mono on linux and noticed that somebody called the Database folder "DataBase". I just corrected it in the project file.
