### PR TITLE
Optimize memory usage and collect it after loading DBC Storage

### DIFF
--- a/SpellWork/DBC/DBC.cs
+++ b/SpellWork/DBC/DBC.cs
@@ -146,15 +146,6 @@ namespace SpellWork.DBC
                     else
                         SpellTriggerStore.Add(triggerId, new SortedSet<int> { effect.SpellID });
                 }
-                    {
-                        if (SpellTriggerStore.ContainsKey(triggerId))
-                            SpellTriggerStore[triggerId].Add(effect.SpellID);
-                        else
-                            SpellTriggerStore.Add(triggerId, new SortedSet<int> { effect.SpellID });
-                    }
-
-                    SpellInfoStore[traitDefinition.SpellID].TraitDefinitions.Add(traitDefinition);
-                }
             }), Task.Run(() =>
             {
                 var spellTargetRestrictions = CreateInstance<Storage<SpellTargetRestrictionsEntry>>("SpellTargetRestrictions", hotfixReader);
@@ -499,7 +490,6 @@ namespace SpellWork.DBC
                 hotfixReader.ApplyHotfixes(storage, db2Reader);
 
             return storage;
-        }
         }
 
         public static uint SelectedLevel = MaxLevel;

--- a/SpellWork/DBC/Structures/ItemEffectEntry.cs
+++ b/SpellWork/DBC/Structures/ItemEffectEntry.cs
@@ -14,5 +14,9 @@ namespace SpellWork.DBC.Structures
         public ushort SpellCategoryID;
         public int SpellID;
         public ushort ChrSpecializationID;
+
+        // Helper
+        public ItemSparseEntry Item { get; set; }
+        public int ItemID { get; set; }
     }
 }

--- a/SpellWork/Database/MySQLConnect.cs
+++ b/SpellWork/Database/MySQLConnect.cs
@@ -108,12 +108,7 @@ namespace SpellWork.Database
                                 continue;
 
                             var spellId = reader.GetUInt32(0);
-                            var spellInfo = new SpellInfo(
-                                new SpellNameEntry()
-                                {
-                                    ID = spellId,
-                                    Name = reader.GetString(61) + " (SERVERSIDE)"
-                                },
+                            var spellInfo = new SpellInfo(reader.GetString(61) + " (SERVERSIDE)",
                                 new SpellEntry()
                                 {
                                     ID = spellId
@@ -346,8 +341,7 @@ namespace SpellWork.Database
                                 SpellID = (int)spellId
                             };
 
-                            spellInfo.Effects.Add(effect);
-                            spellInfo.SpellEffectInfoStore[effect.EffectIndex] = new SpellEffectInfo(effect);
+                            spellInfo.SpellEffectInfoStore.Add(new SpellEffectInfo(effect));
                         }
                     }
                 }

--- a/SpellWork/Forms/FormMain.cs
+++ b/SpellWork/Forms/FormMain.cs
@@ -283,8 +283,8 @@ namespace SpellWork.Forms
                          (!use1Val || filterValFn1(spell)) &&
                          (!use2Val || filterValFn2(spell)) &&
                          ((!use1EffectVal && !use2EffectVal) || spell.SpellEffectInfoStore.Any(effect =>
-                         (!use1EffectVal || filterValEffectFn1(effect.Value)) &&
-                         (!use2EffectVal || filterValEffectFn2(effect.Value)))))
+                         (!use1EffectVal || filterValEffectFn1(effect)) &&
+                         (!use2EffectVal || filterValEffectFn2(effect)))))
                 .OrderBy(spell => spell.ID)
                 .ToList();
 
@@ -746,6 +746,10 @@ namespace SpellWork.Forms
         public void Unblock()
         {
             tabControl1.Enabled = true;
+        }
+        private void FormMain_Shown(object sender, EventArgs e)
+        {
+            _status.Text = $"Initialized in {DBC.DBC.DataLoadedInMs} ms";
         }
     }
 }


### PR DESCRIPTION
Reduced memory usage from 1.3-1.5 GB~ to 550 MB~

After initializing the storage, start collecting memory from the garbage collector.. (we dont need all the overused data anymore)