### PR TITLE
Move AppVeyor definition from UI to appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+version: 1.0.{build}
+image: Visual Studio 2019
+configuration:
+- Debug
+- Release
+platform: Any CPU
+before_build:
+- cmd: nuget restore
+build:
+  verbosity: minimal
+artifacts:
+- path: SpellWork\bin
+  name: SpellWork


### PR DESCRIPTION
Move AppVeyor definition from UI to appveyor.yml to make it easier to test different image versions in PRs when upgrading .NET