### PR TITLE
Fix "Use DB" setting being ignored on startup

### DIFF
--- a/SpellWork/Database/MySQLConnect.cs
+++ b/SpellWork/Database/MySQLConnect.cs
@@ -38,6 +38,9 @@ namespace SpellWork.Database
 
         public static void SelectProc(string query)
         {
+            if (!Connected)
+                return;
+
             Dropped.Clear();
             using (var conn = new MySql.Data.MySqlClient.MySqlConnection(ConnectionString))
             {
@@ -83,6 +86,9 @@ namespace SpellWork.Database
 
         public static void LoadServersideSpells()
         {
+            if (!Connected)
+                return;
+
             var spellsQuery =
                 "SELECT Id, DifficultyID, CategoryId, Dispel, Mechanic, Attributes, AttributesEx, AttributesEx2, AttributesEx3, " +
                 "AttributesEx4, AttributesEx5, AttributesEx6, AttributesEx7, AttributesEx8, AttributesEx9, AttributesEx10, AttributesEx11, AttributesEx12, AttributesEx13, " +
@@ -356,7 +362,7 @@ namespace SpellWork.Database
 
         public static void Insert(string query)
         {
-            if (Settings.Default.DbIsReadOnly)
+            if (!Connected || Settings.Default.DbIsReadOnly)
                 return;
 
             using (var conn = new MySql.Data.MySqlClient.MySqlConnection(ConnectionString))


### PR DESCRIPTION
Fix "Use DB" setting being considered always enabled on startup, loading data from MySQL even with this setting disabled

![image](https://github.com/TrinityCore/SpellWork/assets/1153754/53937dd3-23b0-4973-a8ba-3b15446a91ba)
